### PR TITLE
docs: add CLI reply and resolve-with-reply commands to playbooks

### DIFF
--- a/playbooks/doc-editor/critiquer.md
+++ b/playbooks/doc-editor/critiquer.md
@@ -140,6 +140,12 @@ Comments move through these statuses based on **actions** taken by different rol
 
 **Note**: When the human accepts your feedback, the Writer will receive a notification to implement it. The Writer MUST resolve the comment after making the change - this is what closes the thread.
 
+### Replying via CLI
+
+To reply to user feedback or continue a discussion thread:
+- **Reply**: `hotwired artifact comment reply <comment_id> "message"` — no need to specify path or target text, they are inherited from the parent comment.
+- **Check context first**: `hotwired artifact comment show <comment_id>` — retrieves the full thread before responding.
+
 When listing comments:
 - `status: "open"` - Unreviewed comments (awaiting human decision)
 - `status: "accepted"` - Comments the Writer needs to address

--- a/playbooks/doc-editor/protocol.md
+++ b/playbooks/doc-editor/protocol.md
@@ -136,6 +136,9 @@ Use the `hotwired` CLI for agent-to-agent and agent-to-human communication:
 | `hotwired complete` | Mark your current task as complete |
 | `hotwired status` | Check run state and which agents are connected |
 | `hotwired inbox` | Check for incoming messages |
+| `hotwired artifact comment reply <id> "msg"` | Reply to a comment (inherits parent's path/selection) |
+| `hotwired artifact resolve <id> --reply "msg"` | Leave a closing reply and resolve in one step |
+| `hotwired artifact comment show <id>` | Show a comment and its thread replies |
 
 **Recipients**: Use `orchestrator`, `implementer`, `critiquer`, `writer`, or `human`.
 

--- a/playbooks/doc-editor/writer.md
+++ b/playbooks/doc-editor/writer.md
@@ -222,6 +222,12 @@ doc_artifact_resolve_comment({
 - Use `doc_artifact_resolve_comment` with action `"reply"` to ask for clarification
 - Wait for the human or Critiquer to respond before proceeding
 
+### CLI Comment Shortcuts
+
+When using the `hotwired` CLI:
+- **Resolve with reply**: `hotwired artifact resolve <comment_id> --reply "Addressed in revision N"` — leaves a closing reply and resolves the thread in one step.
+- **Quick reply without resolving**: `hotwired artifact comment reply <comment_id> "message"` — ask for clarification or continue discussion.
+
 ## Document Quality Checklist
 
 Before handing off for review, ensure:


### PR DESCRIPTION
Document `hotwired artifact comment reply` and
`hotwired artifact resolve --reply` in protocol, critiquer, and writer playbooks.